### PR TITLE
Websocket Channels, Global Modules, Logger accepts strings, Config synchronous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ db.sqlite3
 ormconfig.json
 com.plexapp.plugins.library.db*
 .vscode/
+password.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -749,6 +749,15 @@
         "@types/mime": "*"
       }
     },
+    "@types/socket.io": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.4.tgz",
+      "integrity": "sha512-cI98INy7tYnweTsUlp8ocveVdAxENUThO0JsLSCs51cjOP2yV5Mqo5QszMDPckyRRA+PO6+wBgKvGvHUCc23TQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/express": "^4.17.2",
     "@types/jest": "^24.0.23",
     "@types/node": "^12.12.11",
+    "@types/socket.io": "^2.1.4",
     "@types/supertest": "^2.0.8",
     "jest": "^24.9.0",
     "nodemon": "^1.19.4",

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, Global } from '@nestjs/common';
 import { JwtModule, JwtModuleOptions } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -8,6 +8,7 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { User } from './auth.user.entity';
 import { JwtStrategy } from './jwt.strategy';
+@Global()
 @Module({
     imports: [
         PassportModule.register({ defaultStrategy: 'jwt' }),
@@ -21,7 +22,6 @@ import { JwtStrategy } from './jwt.strategy';
             }),
             inject: [ConfigurationService],
         }),
-        SharedModule,
         TypeOrmModule.forFeature([User]),
     ],
     providers: [AuthService, JwtStrategy],

--- a/src/cron/cron.module.ts
+++ b/src/cron/cron.module.ts
@@ -1,9 +1,8 @@
 import { Module } from '@nestjs/common';
 import { CronService } from './cron.service';
-import { SharedModule } from '../shared/shared.module';
 
 @Module({
-    imports: [SharedModule],
+    imports: [],
     providers: [CronService],
     exports: [CronService],
 })

--- a/src/iti/iti.controller.spec.ts
+++ b/src/iti/iti.controller.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AuthModule } from '../auth/auth.module';
 import { RolesGuard } from '../auth/auth.roles';
 import { ItiController } from './iti.controller';
 import { ItiService } from './iti.service';

--- a/src/iti/iti.module.ts
+++ b/src/iti/iti.module.ts
@@ -1,12 +1,10 @@
 import { Module } from '@nestjs/common';
-import { AuthModule } from '../auth/auth.module';
-import { SharedModule } from '../shared/shared.module';
 import { TmdbModule } from '../tmdb/tmdb.module';
 import { ItiController } from './iti.controller';
 import { ItiService } from './iti.service';
 
 @Module({
-  imports: [AuthModule, SharedModule, TmdbModule],
+  imports: [TmdbModule],
   controllers: [ItiController],
   providers: [ItiService],
   exports: [ItiService],

--- a/src/iti/iti.service.spec.ts
+++ b/src/iti/iti.service.spec.ts
@@ -9,7 +9,7 @@ describe('ItiService', () => {
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        {provide: ConfigurationService, useValue: {}},
+        {provide: 'CONFIG', useValue: {}},
         {provide: Logger, useValue: {}},
         {provide: ItiService, useValue: {}},
         {provide: TmdbService, useValue: {}},

--- a/src/jd/file.service.ts
+++ b/src/jd/file.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import * as fs from 'fs-extra';
 import * as parse from 'parse-torrent-name';
 import * as path from 'path';
@@ -13,21 +13,17 @@ import ConfigurationService from '../shared/configuration/configuration.service'
 @Injectable()
 export default class FileService {
     socket: WsGateway;
-    config: IConfiguration;
-    constructor(private readonly configService: ConfigurationService) {
-        this.setConfiguration();
+    constructor(
+        @Inject('CONFIG')
+        private readonly config: IConfiguration) {
     }
 
-    async setConfiguration() {
-        this.config = await this.configService.getConfig();
-    }
 
     setSocket(socket: WsGateway) {
         this.socket = socket;
     }
 
     async unrar(pkg: JdPackage): Promise<boolean> {
-        this.config = await this.configService.getConfig();
         const packages = this.findRars(this.config.filePaths.dir, [pkg]);
         pkg = packages[0];
         return new Promise<boolean>((res, rej) => {
@@ -55,7 +51,6 @@ export default class FileService {
     }
 
     async moveVideos(packages: JdPackage[] = []): Promise<[boolean, JdPackage[]]> {
-        this.config = await this.configService.getConfig();
         packages = this.findVideos(this.config.filePaths.dir, packages);
         const moved = false;
         for (const j in packages) {

--- a/src/jd/jd.module.ts
+++ b/src/jd/jd.module.ts
@@ -1,14 +1,12 @@
 import { Module, UseGuards } from '@nestjs/common';
-import { AuthModule } from '../auth/auth.module';
 import { ItiModule } from '../iti/iti.module';
-import { SharedModule } from '../shared/shared.module';
 import FileService from './file.service';
 import { JdController } from './jd.controller';
 import { JdService } from './jd.service';
 import { CronModule } from '../cron/cron.module';
 
 @Module({
-    imports: [AuthModule, SharedModule, ItiModule, CronModule],
+    imports: [ItiModule, CronModule],
     controllers: [JdController ],
     providers: [JdService, FileService],
     exports: [JdService, FileService],

--- a/src/jd/jd.service.spec.ts
+++ b/src/jd/jd.service.spec.ts
@@ -90,9 +90,7 @@ describe('JdService', () => {
     module = await Test.createTestingModule({
       providers: [
         JdService,
-        {provide: ConfigurationService, useValue: {
-          getConfig: () => config,
-        }},
+        {provide: 'CONFIG', useValue: config},
         {provide: FileService, useValue: { moveVideos }},
         {provide: ItiService, useValue: {}},
         {provide: Logger, useValue: {

--- a/src/jd/jd.service.ts
+++ b/src/jd/jd.service.ts
@@ -75,7 +75,7 @@ export class JdService extends LogMe {
                 packages,
             };
         } else {
-            this.logError('initiate'e, 'No Jdownloader Devices found.');
+            this.logError('initiate', 'No Jdownloader Devices found.');
             throw new HttpException({
                 success: false,
                 error: {

--- a/src/jd/jd.service.ts
+++ b/src/jd/jd.service.ts
@@ -55,7 +55,7 @@ export class JdService extends LogMe {
         const response = !this.isConnected ? await this.connect() : {connected: true};
 
         if (!response.connected) {
-            this.logError(this.initiate, 'Could not connect to Jdownloader', response.error);
+            this.logError('initiate', 'Could not connect to Jdownloader', response.error);
             throw new HttpException({
                 success: false,
                 error: response.error,
@@ -68,14 +68,14 @@ export class JdService extends LogMe {
             if (this.cronId === undefined) {
                 this.setupPollingCache();
             }
-            await this.logInfo(this.initiate, 'Initated connection with Jdownloader');
+            await this.logInfo('initiate', 'Initated connection with Jdownloader');
             return {
                 id: deviceId,
                 success: true,
                 packages,
             };
         } else {
-            this.logError(this.initiate, 'No Jdownloader Devices found.');
+            this.logError('initiate'e, 'No Jdownloader Devices found.');
             throw new HttpException({
                 success: false,
                 error: {
@@ -113,7 +113,7 @@ export class JdService extends LogMe {
         if (this.anyPackagesFinished(true)) {
             const [success, packages] =  await this.fileService.moveVideos(this.finishedPackages);
             const movedPackages = packages.filter(x => x.files.every(y => y && y.moved));
-            await this.logInfo(this.movePackages, `Moved videos: ${movedPackages.map(x =>
+            await this.logInfo('movePackages', `Moved videos: ${movedPackages.map(x =>
                     `${x.files.length} files: ${x.files.length > 0 ? x.files[0].fileName : 'No files moved'} to ${x.files.length > 0 ? x.files[0].destination : 'destination'}`,
             )}`);
             if (movedPackages.length > 0) {
@@ -212,7 +212,7 @@ export class JdService extends LogMe {
                     return pck.data;
                 } catch {}
             }
-            await this.logError(this.getPackages, `Error finding packages`, null);
+            await this.logError('getPackages', `Error finding packages`, null);
             throw new HttpException({
                 success: false,
                 error: {
@@ -246,10 +246,10 @@ export class JdService extends LogMe {
             try {
                 const linksString = links.join(' ');
                 resp = await jdApi.addLinks(linksString, this.deviceId, packageName);
-                await this.logInfo(this.addLinks, `Added ${links.length} links under the name ${packageName}`);
+                await this.logInfo('addLinks', `Added ${links.length} links under the name ${packageName}`);
                 return { success: true};
             } catch (e) {
-                await this.logError(this.addLinks, `Error adding links`, e.error);
+                await this.logError('addLinks', `Error adding links`, e.error);
                 throw new HttpException({
                     success: false,
                     error: e.error,
@@ -328,7 +328,7 @@ export class JdService extends LogMe {
             }
             catch (e) {
 
-                await this.logError(this.getLinks, 'Could not retrieve links', e);
+                await this.logError('getLinks', 'Could not retrieve links', e);
             }
         }
         return [];
@@ -384,7 +384,7 @@ export class JdService extends LogMe {
             return pack;
         }
         catch (e) {
-            this.logError(this.addPackageDetails, 'error adding package details', e);
+            this.logError('addPackageDetails', 'error adding package details', e);
         }
 
     }

--- a/src/jd/jd.service.ts
+++ b/src/jd/jd.service.ts
@@ -11,6 +11,7 @@ import { Logger } from '../shared/log/log.service';
 import { LogMe } from '../shared/log/logme';
 import { WsGateway } from '../ws/ws.gateway';
 import FileService from './file.service';
+import { UserLevel } from '../shared/constants';
 @Injectable()
 export class JdService extends LogMe {
 
@@ -261,8 +262,8 @@ export class JdService extends LogMe {
 
     async cronJob() {
         await this.getPackages(false, null, false);
-        if (this.socket && this.socket.server) {
-            this.socket.server.to(this.socket.authorizedGuid).emit('packages', this.packages);
+        if (this.socket) {
+            this.socket.sendEvent('packages', this.packages, UserLevel.User);
         }
     }
 
@@ -280,7 +281,7 @@ export class JdService extends LogMe {
         this.moveCronId = this.cronService.setup({
             jobName: 'jd:move-packages',
             description: 'Move Finished JDownloader Packages to given directory',
-            interval: '0 * * * *',
+            interval: '0 * * * * *',
             onTick: {
                 service: this,
                 methodName: 'movePackages',

--- a/src/plex/plex.db.ts
+++ b/src/plex/plex.db.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import * as path from 'path';
 import { Database, open as sqlliteOpen } from 'sqlite';
 import { Episode } from '../models/plex';
 import ConfigurationService from '../shared/configuration/configuration.service';
 import { WsGateway } from '../ws/ws.gateway';
+import { IConfiguration } from '../models/config';
 @Injectable()
 export default class PlexDb {
     serverGuid = '4c41cc0c0872f8900cd21d92b15f573ca8dfdd61';
@@ -11,19 +12,17 @@ export default class PlexDb {
     db: Database;
     socket: WsGateway;
 
-    constructor(private configService: ConfigurationService) {}
+    constructor(
+        @Inject('CONFIG')
+        private readonly config: IConfiguration) {}
 
     setSocket(socket: WsGateway) {
         this.socket = socket;
     }
 
-    async config() {
-        return this.configService.getConfig();
-    }
 
     async connect() {
-        const config = await this.config();
-        this.db = await sqlliteOpen(path.join(config.plex.dbLocation, 'com.plexapp.plugins.library.db'), {verbose: true});
+        this.db = await sqlliteOpen(path.join(this.config.plex.dbLocation, 'com.plexapp.plugins.library.db'), {verbose: true});
     }
 
     async tvShowExists(name: string, season: number = -1, episode: number = -1): Promise<boolean> {

--- a/src/plex/plex.module.ts
+++ b/src/plex/plex.module.ts
@@ -1,11 +1,9 @@
 import { Module } from '@nestjs/common';
-import { AuthModule } from '../auth/auth.module';
-import { SharedModule } from '../shared/shared.module';
 import PlexController from './plex.controller';
 import PlexDb from './plex.db';
 
 @Module({
-    imports: [AuthModule, SharedModule],
+    imports: [],
     controllers: [PlexController],
     providers: [PlexDb],
     exports: [PlexDb],

--- a/src/shared/configuration/configuration.provider.ts
+++ b/src/shared/configuration/configuration.provider.ts
@@ -1,0 +1,10 @@
+import ConfigurationService from './configuration.service';
+import { async } from 'rxjs/internal/scheduler/async';
+
+export const configProvider = {
+    provide: 'CONFIG',
+    useFactory: async (service: ConfigurationService) => {
+        return await service.getConfig();
+    },
+    inject: [ConfigurationService]
+};

--- a/src/shared/configuration/configuration.service.ts
+++ b/src/shared/configuration/configuration.service.ts
@@ -13,7 +13,6 @@ export default class ConfigurationService {
     _config: any = {};
     constructor(@InjectRepository(Configurations) private readonly configRepo: Repository<Configurations>)
     {
-        this.retrieveAll();
     }
 
     async getConfig(): Promise<IConfiguration> {
@@ -58,3 +57,4 @@ export default class ConfigurationService {
         return result;
     }
 }
+

--- a/src/shared/log/log.service.ts
+++ b/src/shared/log/log.service.ts
@@ -2,16 +2,22 @@ import { Injectable, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { LogEntry, LogLevel } from './log.entry.entity';
 import { Repository } from 'typeorm';
+import { WsGateway } from '../../ws/ws.gateway';
+import { UserLevel } from '../constants';
 
 @Injectable()
 export class Logger {
     type: any;
+    socket: WsGateway;
     displayLevel: LogLevel = LogLevel.DEBUG;
     constructor(
         @InjectRepository(LogEntry)
         private readonly logger: Repository<LogEntry>,
     ) {}
 
+    public setSocket(gateway: WsGateway) {
+        this.socket = gateway;
+    }
     public async log(logger: string, entrance: any, level: LogLevel, message: string, exception: string = null) {
         return await this.logEntry(logger, entrance, level, message, exception);
     }
@@ -23,6 +29,10 @@ export class Logger {
         logEntry.message = message,
         logEntry.logger = `${logger}.${entrance}()`;
         logEntry.exception = exception;
+        if (this.socket) {
+            this.socket.sendEvent(`logger:${LogLevel[logEntry.level]}`, logEntry, UserLevel.Admin);
+        }
+
         if (level >= this.displayLevel) {
             console.log(JSON.stringify(logEntry));
         }

--- a/src/shared/log/logme.ts
+++ b/src/shared/log/logme.ts
@@ -8,7 +8,7 @@ export class LogMe {
     }
 
     log(entrance: any, level: LogLevel, message: string, exception: string = null) {
-        this.logger.log(this.constructor.name, entrance.name, level, message, exception);
+        this.logger.log(this.constructor.name, typeof entrance === 'string' ? entrance : entrance.name, level, message, exception);
     }
 
     logInfo(entrance, message) {

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -1,10 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, Global } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import Configurations from './configuration/configuration.entity';
 import ConfigurationService from './configuration/configuration.service';
 import { LogEntry } from './log/log.entry.entity';
 import { Logger } from './log/log.service';
 
+@Global()
 @Module({
     imports: [TypeOrmModule.forFeature([LogEntry, Configurations])],
     providers: [ConfigurationService, Logger],

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -2,13 +2,14 @@ import { Module, Global } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import Configurations from './configuration/configuration.entity';
 import ConfigurationService from './configuration/configuration.service';
+import { configProvider } from './configuration/configuration.provider';
 import { LogEntry } from './log/log.entry.entity';
 import { Logger } from './log/log.service';
 
 @Global()
 @Module({
     imports: [TypeOrmModule.forFeature([LogEntry, Configurations])],
-    providers: [ConfigurationService, Logger],
-    exports: [ConfigurationService, Logger],
+    providers: [ConfigurationService, Logger, configProvider],
+    exports: [ConfigurationService, Logger, configProvider],
 })
 export class SharedModule {}

--- a/src/subscriptions/subscriptions.controller.spec.ts
+++ b/src/subscriptions/subscriptions.controller.spec.ts
@@ -1,8 +1,5 @@
-import { APP_GUARD } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
-import { AuthModule } from '../auth/auth.module';
 import { RolesGuard } from '../auth/auth.roles';
-import { JwtStrategy } from '../auth/jwt.strategy';
 import { SubscriptionsController } from './subscriptions.controller';
 import { SubscriptionsService } from './subscriptions.service';
 

--- a/src/subscriptions/subscriptions.module.ts
+++ b/src/subscriptions/subscriptions.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { AuthModule } from '../auth/auth.module';
 import { ItiModule } from '../iti/iti.module';
 import { JdModule } from '../jd/jd.module';
 import { PlexModule } from '../plex/plex.module';
-import { SharedModule } from '../shared/shared.module';
 import { TmdbModule } from '../tmdb/tmdb.module';
 import { MovieSubscription } from './movie-subscription.entity';
 import { SubscriptionsController } from './subscriptions.controller';
@@ -13,7 +11,14 @@ import { TvSubscription } from './tv-subscription.entity';
 import { CronModule } from '../cron/cron.module';
 
 @Module({
-    imports: [ TypeOrmModule.forFeature([TvSubscription, MovieSubscription]), CronModule, ItiModule, JdModule, AuthModule, SharedModule, PlexModule, TmdbModule],
+    imports: [
+        TypeOrmModule.forFeature([TvSubscription, MovieSubscription]), 
+        CronModule,
+        ItiModule,
+        JdModule,
+        PlexModule,
+        TmdbModule,
+    ],
     providers: [SubscriptionsService],
     controllers: [SubscriptionsController],
 })

--- a/src/tmdb/tmdb.module.ts
+++ b/src/tmdb/tmdb.module.ts
@@ -1,11 +1,9 @@
 import { Module } from '@nestjs/common';
-import { AuthModule } from '../auth/auth.module';
-import { SharedModule } from '../shared/shared.module';
 import { TmdbController } from './tmdb.controller';
 import { TmdbService } from './tmdb.service';
 
 @Module({
-  imports: [SharedModule, AuthModule],
+  imports: [],
   controllers: [TmdbController],
   providers: [TmdbService],
   exports: [TmdbService],

--- a/src/tmdb/tmdb.service.spec.ts
+++ b/src/tmdb/tmdb.service.spec.ts
@@ -6,7 +6,7 @@ describe('TmdbService', () => {
   let service: TmdbService;
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TmdbService, {provide: ConfigurationService, useValue: {}}],
+      providers: [TmdbService, {provide: 'CONFIG', useValue: {}}],
     }).compile();
     service = module.get<TmdbService>(TmdbService);
   });

--- a/src/ws/ws.gateway.ts
+++ b/src/ws/ws.gateway.ts
@@ -23,7 +23,6 @@ export class WsGateway implements OnGatewayInit, OnGatewayConnection {
   @WebSocketServer() server: Server;
   clients: any = [];
   guids: {[level: number]: string } = {};
-  authorizedGuid: string;
   adminGuid: string;
   constructor(private jdService: JdService,
               private fileService: FileService,
@@ -109,7 +108,6 @@ export class WsGateway implements OnGatewayInit, OnGatewayConnection {
   private joinChannels(client, user) {
     client.authorized = true;
     client.user = user;
-    client.join(this.authorizedGuid);
     for (const i in UserLevel) {
       if (this.guids[i] && user.level >= i) {
         client.join(this.guids[i]);
@@ -118,7 +116,6 @@ export class WsGateway implements OnGatewayInit, OnGatewayConnection {
   }
   private leaveChannels(client) {
     client.authorized = false;
-    client.leave(this.authorizedGuid);
     for (const i in UserLevel) {
       if (this.guids[i] && client.user.level >= i) {
         client.leave(this.guids[i]);

--- a/src/ws/ws.gateway.ts
+++ b/src/ws/ws.gateway.ts
@@ -15,49 +15,64 @@ import { JdPackage } from '../models/jdownloader';
 import { IUser } from '../models/user';
 import PlexDb from '../plex/plex.db';
 import { UserLevel } from '../shared/constants';
+import { Logger } from '../shared/log/log.service';
+import { LogEntry, LogLevel } from '../shared/log/log.entry.entity';
+import { Server } from 'socket.io';
 @WebSocketGateway()
 export class WsGateway implements OnGatewayInit, OnGatewayConnection {
-  @WebSocketServer() server;
+  @WebSocketServer() server: Server;
   clients: any = [];
-
+  guids: {[level: number]: string } = {};
   authorizedGuid: string;
-
+  adminGuid: string;
   constructor(private jdService: JdService,
               private fileService: FileService,
               private authService: AuthService,
               private jwtStrategy: JwtStrategy,
-              private plexDb: PlexDb) {
-      this.authorizedGuid = guid();
+              private plexDb: PlexDb,
+              private logger: Logger) {
+
   }
 
   afterInit(server) {
     this.jdService.setSocket(this);
     this.plexDb.setSocket(this);
     this.fileService.setSocket(this);
+    this.logger.setSocket(this);
+  }
+
+  generateChannels() {
+    this.guids[UserLevel.User] = guid();
+    this.guids[UserLevel.ItiUser] = guid();
+    this.guids[UserLevel.Admin] = guid();
+    this.guids[UserLevel.SuperAdmin] = guid();
   }
 
   @SubscribeMessage('authorization')
   async authorizeUser(client, token) {
     const decoded = await this.jwtStrategy.verifyJwt(token) as IUser;
     if (decoded && decoded.level > UserLevel.Guest) {
-      client.authorized = true;
-      client.user = decoded;
-      client.join(this.authorizedGuid);
-      return true;
-    }
-    else {
+      return this.joinChannels(client, decoded);
+    } else {
       return false;
     }
-
   }
 
   @SubscribeMessage('logout')
   async logout(client) {
-    client.leave(this.authorizedGuid);
+    this.leaveChannels(client);
   }
 
   handleConnection(client) {
     this.clients.push(client);
+  }
+
+  sendEvent(event: string, data: any, userLevel: UserLevel) {
+    if (userLevel > UserLevel.Guest) {
+      this.server.to(this.guids[userLevel]).emit(event, data);
+    } else {
+      this.server.emit(event, data);
+    }
   }
 
   @SubscribeMessage('packages')
@@ -91,7 +106,27 @@ export class WsGateway implements OnGatewayInit, OnGatewayConnection {
     }
   }
 
-  async requestImage(link: string) {
+  private joinChannels(client, user) {
+    client.authorized = true;
+    client.user = user;
+    client.join(this.authorizedGuid);
+    for (const i in UserLevel) {
+      if (this.guids[i] && user.level >= i) {
+        client.join(this.guids[i]);
+      }
+    }
+  }
+  private leaveChannels(client) {
+    client.authorized = false;
+    client.leave(this.authorizedGuid);
+    for (const i in UserLevel) {
+      if (this.guids[i] && client.user.level >= i) {
+        client.leave(this.guids[i]);
+      }
+    }
+    client.user = undefined;
+  }
+  private async requestImage(link: string) {
     const response = await axios.get(link, {responseType: 'arraybuffer' });
     const data = 'data:' + response.headers['content-type'] + ';base64,' + new Buffer(response.data).toString('base64');
     return data;

--- a/src/ws/ws.module.ts
+++ b/src/ws/ws.module.ts
@@ -1,13 +1,11 @@
 import { Module } from '@nestjs/common';
-import { AuthModule } from '../auth/auth.module';
 import { ItiModule } from '../iti/iti.module';
 import { JdModule } from '../jd/jd.module';
 import { PlexModule } from '../plex/plex.module';
-import { SharedModule } from '../shared/shared.module';
 import { WsGateway } from './ws.gateway';
 
 @Module({
-    imports: [SharedModule, AuthModule, JdModule, ItiModule, PlexModule],
+    imports: [JdModule, ItiModule, PlexModule],
     providers: [WsGateway],
 })
 export class WsModule {}


### PR DESCRIPTION
- Websocket Channels
    * Channels for each level of UserLevel. As a result, can send messages to admins only, guests only, etc. Previously was just authorized channel or not.
    

- Global Modules
   * Shared and Auth module were being used close to everywhere. Figured out that nest has `@Global` decorator that let's it be available everywhere if declared in the root module

- Logger 
    * there was no reason to take the full method as the entrance, changed it to allow a string as well
    * also added an event for logging events to websockets.

- The configuration values previously available via an asynchronous database read now ensure the values are available immediately.  This is done by a custom provider.
